### PR TITLE
macOS and White Label exemsi doc updates

### DIFF
--- a/docs/sensor_installation/macOS_sensor_installation-latest.md
+++ b/docs/sensor_installation/macOS_sensor_installation-latest.md
@@ -7,11 +7,16 @@ This document provides details of how to install, verify, and uninstall the Lima
 <u>Table of Contents</u>
 
 [Installation Flow](#Installation-Flow)
+
 [Verifying the installation](#Verifying-Installation)
+
 [Uninstallation Flow](#Uninstallation-Flow)
+
+[Installer Options](#Installer-Options)
+
 [System Requirements](#System-Requirements)
 
-
+<a name="Installation-Flow"></a>
 
 ## Installation Flow
 
@@ -61,8 +66,9 @@ The installation is now complete and you should see a message indicating that th
 
 <img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/Installation/09-Success.png" alt="Success" style="zoom:50%;" />
 
-
+<a name="Verifying-Installation"></a>
 ## Verifying Installation
+
 To verify that the sensor was installed successfully, you can log into the LimaCharlie web application and see if the device has appeared in the Sensors section.  Additionally, you can check the following on the device itself:
 
 In a Terminal, run the command:
@@ -99,7 +105,7 @@ We're aware this is an inconvenience and hope Apple will provide better solution
 
 
 
-
+<a name="Uninstallation-Flow"></a>
 ## Uninstallation Flow
 
 To uninstall the sensor:
@@ -123,7 +129,21 @@ The related system extension will be removed and the RPHCP.app will be removed f
 <img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/Uninstallation/3-Uninstall_Success.png" alt="Uninstall success" style="zoom:100%;" />
 
 
+<a name="Installer-Options"></a>
+## Installer Options
 
+When running the installer from the command line, you can pass the following arguments:
+
+-v: display build version.
+-d <INSTALLATION_KEY>: the deployment key to use to enroll, no permanent installation.
+-i <INSTALLATION_KEY>: install executable as a service with deployment key.
+-r: uninstall executable as a service.
+-c: uninstall executable as a service and delete identity files.
+-w: executable is running as a macOS service.
+-h: displays the list of accepted arguments.
+
+
+<a name="System-Requirements"></a>
 ## System Requirements
 
 **Supported OS' & Hardware**

--- a/docs/sensor_installation/macOS_sensor_installation-latest.md
+++ b/docs/sensor_installation/macOS_sensor_installation-latest.md
@@ -136,7 +136,7 @@ When running the installer from the command line, you can pass the following arg
 
 -v: display build version.
 
--d <INSTALLATION_KEY>: the deployment key to use to enroll, no permanent installation.
+-d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.
 
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
 

--- a/docs/sensor_installation/macOS_sensor_installation-latest.md
+++ b/docs/sensor_installation/macOS_sensor_installation-latest.md
@@ -135,12 +135,19 @@ The related system extension will be removed and the RPHCP.app will be removed f
 When running the installer from the command line, you can pass the following arguments:
 
 -v: display build version.
+
 -d <INSTALLATION_KEY>: the deployment key to use to enroll, no permanent installation.
+
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
+
 -r: uninstall executable as a service.
+
 -c: uninstall executable as a service and delete identity files.
+
 -w: executable is running as a macOS service.
+
 -h: displays the list of accepted arguments.
+
 
 
 <a name="System-Requirements"></a>

--- a/docs/sensor_installation/macOS_sensor_installation-older.md
+++ b/docs/sensor_installation/macOS_sensor_installation-older.md
@@ -7,12 +7,15 @@ This document provides details of how to install, verify, and uninstall the Lima
 <u>Table of Contents</u>
 
 [Installation Flow](#Installation-Flow)
+
 [Verifying the installation](#Verifying-Installation)
+
 [Uninstallation Flow](#Uninstallation-Flow)
+
 [System Requirements](#System-Requirements)
 
 
-
+<a name="Installation-Flow"></a>
 ## Installation Flow
 
 1. Download the [Sensor installer file](https://app.limacharlie.io/get/mac/64)
@@ -53,9 +56,12 @@ The installation is now complete and you should see a message indicating that th
 
 
 
-
+<a name="Verifying-Installation"></a>
 ## Verifying Installation
+
 To verify that the sensor was installed successfully, you can log into the LimaCharlie web application and see if the device has appeared in the Sensors section.  Additionally, you can check the following on the device itself:
+
+**Ensure the process is running**
 
 In a Terminal, run the command:
 
@@ -64,6 +70,20 @@ In a Terminal, run the command:
 <img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/macOS_10.14/Installed_correctly.png" alt="Successful installation verification" style="zoom:50%;" />
 
 If the agent is running, this command should return a record as shown above.
+
+
+
+**Ensure the Kernel Extension is loaded**
+
+You can confirm that the kernel extension is loaded by running the command:
+
+> kextstat | grep com.refractionpoint.
+
+
+
+<img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/macOS_10.14/verifying-extension.png" alt="Successful installation verification" style="zoom:50%;" />
+
+If the extension is loaded, this command should return a record as shown above.
 
 
 
@@ -79,7 +99,7 @@ We're aware this is an inconvenience and hope Apple will provide better solution
 
 
 
-
+<a name="Uninstallation-Flow"></a>
 ## Uninstallation Flow
 
 To uninstall the sensor:
@@ -96,9 +116,22 @@ You'll pass the argument -c
 
 <img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/Uninstallation/3-Uninstall_Success.png" alt="Uninstall success" style="zoom:100%;" />
 
+<a name="Installer-Options"></a>
+## Installer Options
 
+When running the installer from the command line, you can pass the following arguments:
 
-## Supported OS' & Hardware
+-v: display build version.
+-d <INSTALLATION_KEY>: the deployment key to use to enroll, no permanent installation.
+-i <INSTALLATION_KEY>: install executable as a service with deployment key.
+-r: uninstall executable as a service.
+-c: uninstall executable as a service and delete identity files.
+-w: executable is running as a macOS service.
+-h: displays the list of accepted arguments.
+
+<a name="System-Requirements"></a>
+## System Requirements
+
 - macOS version 10.9 to macOS 11 are supported
 - Supported on both Intel (64-bit) and Apple Silicon based hardware 
 

--- a/docs/sensor_installation/macOS_sensor_installation-older.md
+++ b/docs/sensor_installation/macOS_sensor_installation-older.md
@@ -123,7 +123,7 @@ When running the installer from the command line, you can pass the following arg
 
 -v: display build version.
 
--d <INSTALLATION_KEY>: the deployment key to use to enroll, no permanent installation.
+-d <INSTALLATION_KEY>: the installation key to use to enroll, no permanent installation.
 
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
 

--- a/docs/sensor_installation/macOS_sensor_installation-older.md
+++ b/docs/sensor_installation/macOS_sensor_installation-older.md
@@ -122,12 +122,19 @@ You'll pass the argument -c
 When running the installer from the command line, you can pass the following arguments:
 
 -v: display build version.
+
 -d <INSTALLATION_KEY>: the deployment key to use to enroll, no permanent installation.
+
 -i <INSTALLATION_KEY>: install executable as a service with deployment key.
+
 -r: uninstall executable as a service.
+
 -c: uninstall executable as a service and delete identity files.
+
 -w: executable is running as a macOS service.
+
 -h: displays the list of accepted arguments.
+
 
 <a name="System-Requirements"></a>
 ## System Requirements

--- a/docs/white_labelling/windows_sensor_installer_using_exemsi.md
+++ b/docs/white_labelling/windows_sensor_installer_using_exemsi.md
@@ -4,6 +4,33 @@ You can white label the LimaCharlie installer for Windows by using an MSI wrappe
 
 
 
+<u>Table of Contents</u>
+
+[Prerequisites](#Prerequisites)
+
+[Instructions](#Instructions)
+
+[Experience when running the MSI](#Experience)
+
+
+
+
+<a name="Prerequisites"></a>
+## Prerequisites
+
+1.  An MSI wrapper application, such as the exemsi application referenced in the instructions below
+
+2. A digital code signing certificate from Microsoft (optional, but highly recommended)
+
+
+
+Without a digital code signing certificate from Microsoft, the installer will show a warning that the MSI installer is from an unknown publisher.
+
+<img src="https://storage.googleapis.com/limacharlie-io/doc/white-label/exemsi-instructions/uac-signed.png" alt="UAC Signed" style="zoom:80%;" /> - vs - <img src="https://storage.googleapis.com/limacharlie-io/doc/white-label/exemsi-instructions/uac-warning.png" alt="UAC Warning" style="zoom:80%;" />
+
+
+
+<a name="Instructions"></a>
 ## Instructions
 
 1. Download the [LimaCharlie sensor EXE](https://app.limacharlie.io/get/windows/64)
@@ -96,11 +123,12 @@ To provide the option to uninstall, set the Uninstall argument to "-c" (note tha
 <img src="https://storage.googleapis.com/limacharlie-io/doc/white-label/exemsi-instructions/MSI_Wrapper_-_11_-_Status.png" alt="exemsi" style="zoom:100%;" />
 
 
+Once you have created the MSI package you should sign it using your digital signature.  You can [learn more about signing the MSI on the exemsi website](https://www.exemsi.com/documentation/sign-your-msi/).
 
 ***
 
 
-
+<a name="Experience"></a>
 ## Experience when running the MSI
 
 When installing the application using the MSI you'll see your application name in the title bar.
@@ -120,7 +148,3 @@ In the Apps & Features section of Windows, you'll see the application listed und
 <img src="https://storage.googleapis.com/limacharlie-io/doc/white-label/exemsi-instructions/Shown_in_Control_Panel_-_Apps_and_Features.png" alt="exemsi" style="zoom:100%;" />
 
 ***
-
-
-
-Once you have created the MSI package you may wish to sign it using your digital signature.  You can [learn more about signing the MSI on the exemsi website](https://www.exemsi.com/documentation/sign-your-msi/).

--- a/docs/white_labelling/windows_sensor_installer_using_exemsi.md
+++ b/docs/white_labelling/windows_sensor_installer_using_exemsi.md
@@ -20,11 +20,11 @@ You can white label the LimaCharlie installer for Windows by using an MSI wrappe
 
 1.  An MSI wrapper application, such as the exemsi application referenced in the instructions below
 
-2. A digital code signing certificate from Microsoft (optional, but highly recommended)
+2. A digital code signing certificate  (optional, but highly recommended)
 
 
 
-Without a digital code signing certificate from Microsoft, the installer will show a warning that the MSI installer is from an unknown publisher.
+Without a digital code signing certificate the installer will show a warning that it is from an unknown publisher.
 
 <img src="https://storage.googleapis.com/limacharlie-io/doc/white-label/exemsi-instructions/uac-signed.png" alt="UAC Signed" style="zoom:80%;" /> - vs - <img src="https://storage.googleapis.com/limacharlie-io/doc/white-label/exemsi-instructions/uac-warning.png" alt="UAC Warning" style="zoom:80%;" />
 


### PR DESCRIPTION
Put the code signing information up front for the exemsi doc so users saw that immediately.

Added more verification / troubleshooting info for older versions of macOS & fixed table of contents anchor issue.