### PR TITLE
Clarified required fields for Outputs of type Webhook Bulk and SMTP

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -143,7 +143,7 @@ is_no_header: "false"
 Output individually each event, detection, audit, deployment or artifact through a POST webhook.
 
 * `dest_host`: the IP or DNS, port and page to HTTP(S) POST to, format `https://www.myorg.com:514/whatever`.
-* `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the webhook to verify authenticity. See "Webhook" section below.
+* `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the webhook to verify authenticity. See "Webhook Details" section below.
 * `auth_header_name` and `auth_header_value`: set a specific value to a specific HTTP header name in the outgoing webhooks.
 
 Example:
@@ -158,8 +158,10 @@ auth_header_value: 4756345846583498
 Output batches of events, detections, audits, deployments or artifacts through a POST webhook.
 
 * `dest_host`: the IP or DNS, port and page to HTTP(S) POST to, format `https://www.myorg.com:514/whatever`.
-* `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the webhook to verify authenticity. See "Webhook" section below.
+* `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the webhook to verify authenticity. This is a required field. See "Webhook Details" section below.
 * `auth_header_name` and `auth_header_value`: set a specific value to a specific HTTP header name in the outgoing webhooks.
+* `sec_per_file`: the number of seconds after which a file is cut and uploaded.
+
 
 Example:
 ```
@@ -177,7 +179,7 @@ Output individually each event, detection, audit, deployment or log through an e
 * `from_email`: the email address to set in the From field of the email sent.
 * `username`: the username (if any) to authenticate with the SMTP server with.
 * `password`: the password (if any) to authenticate with the SMTP server with.
-* `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the email to verify authenticity. See "Webhook" section below.
+* `secret_key`: an arbitrary shared secret used to compute an HMAC (SHA256) signature of the email to verify authenticity. This is a required field. See "Webhook Details" section below.
 * `is_readable`: if 'true' the email format will be HTML and designed to be readable by a human instead of a machine.
 * `is_starttls`: if 'true', use the Start TLS method of securing the connection instead of pure SSL.
 * `is_authlogin`: if 'true', authenticate using `AUTH LOGIN` instead of `AUTH PLAIN`.
@@ -419,7 +421,7 @@ be notified of this by special events in the stream like this: `{"__trace":"drop
 that were dropped. If no data is present in the stream (like rare detections), you will also receive a `{"__trace":"keepalive"}`
 message aproximately every minute to indicate the stream is still alive.
 
-### Webhook
+### Webhook Details
 Using this ouput, every element will be sent over HTTP(S) to a webserver of your choice via a POST.
 
 The JSON data will be found in the `data` parameter of the `application/x-www-form-urlencoded` encoded POST.


### PR DESCRIPTION
## Description of the change

Clarified required fields for Outputs of type Webhook Bulk and SMTP
Renamed second instance of Webhooks heading for clarity

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#595](https://github.com/refractionpoint/tracking/issues/595) 
