### PR TITLE
Early doc for Slack Outputs.

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -111,8 +111,6 @@ password: XXXXXXXXXXXX
 
 ### Slack
 Output detections and audit (only) to a Slack community and channel.
-The Slack integration currently uses [Slack Legacy Tokens](https://api.slack.com/custom-integrations/legacy-tokens).
-
 
 * `slack_api_token`: the Slack provided API token used to authenticate.
 * `slack_channel`: the channel to output to in the community.
@@ -122,6 +120,17 @@ Example:
 slack_api_token: d8vyd8yeugr387y8wgf8evfb
 slack_channe: #detections
 ```
+
+#### Provisioning
+To use this Output, you need to create a Slack App and Bot. This is very simple:
+1- Head over to https://api.slack.com/apps
+1- Click on "Create App" and select the workspace where it should go
+1- From the sidebar, click on OAuth & Permissions
+1- Go to the section "Bot Token Scope" and click "Add an OAuth Scope"
+1- Select the scope `chat:write`
+1- From the sidebar, click "Install App" and then "Install to Workspace"
+1- Copy token shown, this is the `slack_api_token` you need in LimaCharlie
+1- In your Slack workspace, go to the channel you want receive messages in and type the slash command: `/invite @limacharlie` (assuming the app name is `limacharlie`)
 
 ### Syslog (TCP)
 Output events and detections to a syslog target.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -118,7 +118,7 @@ Output detections and audit (only) to a Slack community and channel.
 Example:
 ```
 slack_api_token: d8vyd8yeugr387y8wgf8evfb
-slack_channe: #detections
+slack_channel: #detections
 ```
 
 #### Provisioning


### PR DESCRIPTION
## Description of the change

Updating the Slack documentation for the Output. Used to use Legacy Tokens, now uses a basic OAuth token.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
