### PR TITLE
Update tagging.md

### DIFF
--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -45,3 +45,9 @@ When you tag a sensor with _latest_, the sensor version currently assigned to th
 
 ### experimental
 When you tag a sensor with _experimental_, the sensor version currently assigned to the Organization will be ignored for that specific sensor. An experimental version of the sensor will be used instead. This tag is typically used when working with the LimaCharlie team to troubleshoot sensor-specific issues.
+
+### no_kernel
+When you tag a sensor with _experimental_, the kernel component will not be loaded on the host. 
+
+### debug
+When you tag a sensor with _debug_, the debug version of the sensor currently assigned to the Organization will be used. 

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -47,7 +47,7 @@ When you tag a sensor with _latest_, the sensor version currently assigned to th
 When you tag a sensor with _experimental_, the sensor version currently assigned to the Organization will be ignored for that specific sensor. An experimental version of the sensor will be used instead. This tag is typically used when working with the LimaCharlie team to troubleshoot sensor-specific issues.
 
 ### no_kernel
-When you tag a sensor with _experimental_, the kernel component will not be loaded on the host. 
+When you tag a sensor with _no_kernel_, the kernel component will not be loaded on the host. 
 
 ### debug
 When you tag a sensor with _debug_, the debug version of the sensor currently assigned to the Organization will be used. 


### PR DESCRIPTION
Added 2 tags discussed yesterday - 

### no_kernel
When you tag a sensor with _experimental_, the kernel component will not be loaded on the host. 

### debug
When you tag a sensor with _debug_, the debug version of the sensor currently assigned to the Organization will be used.

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

