### PR TITLE
Typo fix for GCS output

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -49,7 +49,7 @@ is_compression: "true"
 ### Google Cloud Storage
 Output events and detections to a GCS bucket.
 
-* `bucket`: the path to the AWS S3 bucket.
+* `bucket`: the path to the GCS bucket.
 * `secret_key`: the secret json key identifying a service account.
 * `sec_per_file`: the number of seconds after which a file is cut and uploaded.
 * `is_compression`: if set to "true", data will be gzipped before upload.


### PR DESCRIPTION
## Description of the change

Updated typo where we incorrectly referenced AWS in the GCS section

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Describe multi-tenancy segmentation

N/A