### PR TITLE
New plat checks

### DIFF
--- a/docs/dr.md
+++ b/docs/dr.md
@@ -351,8 +351,32 @@ max: 2
 
 This would match `svhost.exe` and `csrss32.exe` but NOT `csrsswin32.exe`.
 
-##### is windows, is linux, is mac, is chrome, is text, is json, is gcp, is carbon_black, is 32 bit, is 64 bit, is arm
+##### is 32 bit, is 64 bit, is arm
 All of these operators take no additional arguments, they simply match if the relevant sensor characteristic is correct.
+
+##### is platform
+Checks if the event under evaluation is from a sensor of the given platform.
+
+Takes a `name` parameter for the platform name. The current platforms are:
+* `windows`
+* `linux`
+* `macos`
+* `ios`
+* `android`
+* `chrome`
+* `vpn`
+* `text`
+* `json`
+* `gcp`
+* `aws`
+* `carbon_black`
+* `1password`
+
+Example:
+```yaml
+op: is platform
+name: 1password
+```
 
 ##### is tagged
 Determines if the tag supplied in the `tag` parameter is already associated with the sensor that the event under evaluation is from.

--- a/docs/dr.md
+++ b/docs/dr.md
@@ -354,6 +354,11 @@ This would match `svhost.exe` and `csrss32.exe` but NOT `csrsswin32.exe`.
 ##### is 32 bit, is 64 bit, is arm
 All of these operators take no additional arguments, they simply match if the relevant sensor characteristic is correct.
 
+Example:
+```yaml
+op: is 64 bit
+```
+
 ##### is platform
 Checks if the event under evaluation is from a sensor of the given platform.
 


### PR DESCRIPTION
## Description of the change

Moving the platform checks to a format that will scale better with the high number of new platforms coming. This will mean we're not required to add brand new one-off operators to the engine for new platforms.

Engine still supports the old way (like `is windows`) for backwards compatibility.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

