### PR TITLE
Tiny blurb for healthchecks.

### DIFF
--- a/docs/lc_adapter.md
+++ b/docs/lc_adapter.md
@@ -48,6 +48,12 @@ Configurations can be provided to the adapter in one of three ways:
 1. By specifying the configurations via the command line in the format `config-name=config-value`.
 1. By specifying the configurations via the environment variables in the format `config-name=config-value`.
 
+### Runtime Configuration
+
+The Adapter runtime supports some custom behaviors to make it more suitable for specific deployment scenarios:
+
+* `healthcheck`: an integer that specifies a port to start an HTTP server on that can be used for healthchecks.
+
 ### Core Configuration
 
 All Adapter Types support the same `client_options`, plus type-specific configurations. You should always specify the following configurations:


### PR DESCRIPTION
## Description of the change

Documenting a `healthcheck` parameter that can be used to deploy the Adapter in cloud based platforms that require a health check, like Cloud Run.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


