### PR TITLE
Small note indicating Watch rules are not case sensitive.

### DIFF
--- a/docs/exfil.md
+++ b/docs/exfil.md
@@ -16,7 +16,7 @@ The Watch Rules allow you to specify a platform and tag to select which sensors 
 * Event: the specific event type that should be evaluated, like `MODULE_LOAD`.
 * Path: the path within the `event` component whose value should be evaluated, like `FILE_PATH`.
 * Operator: the type of evaluation/comparison that should be done between the value at Path in the event and the Value.
-* Value: the value used in the comparison.
+* Value: the value used in the comparison (case incensitive).
 
 For example:
 ```

--- a/docs/exfil.md
+++ b/docs/exfil.md
@@ -16,7 +16,7 @@ The Watch Rules allow you to specify a platform and tag to select which sensors 
 * Event: the specific event type that should be evaluated, like `MODULE_LOAD`.
 * Path: the path within the `event` component whose value should be evaluated, like `FILE_PATH`.
 * Operator: the type of evaluation/comparison that should be done between the value at Path in the event and the Value.
-* Value: the value used in the comparison (case incensitive).
+* Value: the value used in the comparison (case insensitive).
 
 For example:
 ```


### PR DESCRIPTION
## Description of the change

Add a note about how Watch rules in Exfil are not case sensitive.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

