### PR TITLE
Adding note to s3 doc about region.

### DIFF
--- a/docs/output-destinations.md
+++ b/docs/output-destinations.md
@@ -25,7 +25,7 @@ Output events and detections to an Amazon S3 bucket.
 * `sec_per_file`: the number of seconds after which a file is cut and uploaded.
 * `is_compression`: if set to "true", data will be gzipped before upload.
 * `is_indexing`: if set to "true", data is uploaded in a way that makes it searchable.
-* `region_name`: optionally specify a region name.
+* `region_name`: a region name of the bucket, it is recommended to set it, though not always required.
 * `endpoint_url`: optionally specify a custom endpoint URL, usually used with region_name to output to S3-compatible 3rd party services.
 * `dir`: the directory prefix
 

--- a/docs/output-destinations.md
+++ b/docs/output-destinations.md
@@ -25,7 +25,7 @@ Output events and detections to an Amazon S3 bucket.
 * `sec_per_file`: the number of seconds after which a file is cut and uploaded.
 * `is_compression`: if set to "true", data will be gzipped before upload.
 * `is_indexing`: if set to "true", data is uploaded in a way that makes it searchable.
-* `region_name`: a region name of the bucket, it is recommended to set it, though not always required.
+* `region_name`: the region name of the bucket, it is recommended to set it, though not always required.
 * `endpoint_url`: optionally specify a custom endpoint URL, usually used with region_name to output to S3-compatible 3rd party services.
 * `dir`: the directory prefix
 


### PR DESCRIPTION
## Description of the change

The S3 APIs are odd, depending on the region (and maybe more), the region name is sometimes required and if omitted it may result in a permission denied.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


