### PR TITLE
New deployment event on cloud adapter auto-disable.

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1538,6 +1538,23 @@ Quota changed events are emitted when the quota for an Organization changes.
 }
 ```
 
+### cloud_adapter_disabled
+
+This event is emitted when a Cloud Adapter gets disabled because it has been erroring for a long period of time.
+
+```json
+{
+  "event":{
+    "error": "invalid api key"
+  },
+  "routing": {
+    "event_time": 1644444297696,
+    "event_type": "cloud_adapter_disabled",
+    "oid": "8cbe27f4-aaaa-cccc-bbbb-138cd51389cd"
+  }
+}
+```
+
 ## Artifact Events
 
 Events around artifact collection, observable in D&R rules via the `artifact_event` target.


### PR DESCRIPTION
## Description of the change

Documenting a new `deployment` event we emit when a cloud adapter gets automatically disabled after it's been failing for a long time (currently 24h).

This allows users to get a notification of this happening and remedy it.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
