### PR TITLE
Document tasking support for template strings.

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -16,6 +16,8 @@ Sends a task in the `command` parameter to the sensor that the event under evalu
 
 An optional `investigation` parameter can be given to create a unique identifier for the task and any events emitted from the sensor as a result of the task.
 
+The `command` parameter supports [string templates](./template_and_transforms.md) like `artifact_get {{ .event.FILE_PATH }}`.
+
 > To view all possible commands, see [Reference: Sensor Commands](sensor_commands.md)
 
 ## report


### PR DESCRIPTION
## Description of the change

We've added support for template string in D&R rule's Task.
This allows us to support users filling in parameters in the task directly without using the "tokenized" form.

Before:
```yaml
- action: task
  command:
    - deny_tree
    - <<routing/parent>>
```

Now:
```yaml
- action: task
  command: deny_tree {{ .routing.parent }}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


