### PR TITLE
Fix the curl example for sigma-converter.

### DIFF
--- a/docs/sigma-converter.md
+++ b/docs/sigma-converter.md
@@ -28,7 +28,7 @@ Output Example:
 
 CURL Example:
 ```
-curl -X POST  https://sigma.limacharlie.io/convert/repo -d "rule=@my-rule-file.yaml"
+curl -X POST  https://sigma.limacharlie.io/convert/rule -H 'content-type: application/x-www-form-urlencoded' --data-urlencode "rule@my-rule-file.yaml"
 ```
 
 ### Multiple Rules


### PR DESCRIPTION
## Description of the change

I think different versions of curl support different syntax, this example seems to have been problematic, this new version works better.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


