### PR TITLE
Update lc-edr.md

### DIFF
--- a/docs/lc-edr.md
+++ b/docs/lc-edr.md
@@ -12,24 +12,24 @@ A versatile YAML-based detection syntax can be used to create detections for hig
 
 This same detection syntax can also be used to easily achieve the following:
 
-Running Sigma rules
-Running continuous YARA scans without impacting performance
-File and registry integrity monitoring
-Leveraging threat feeds or lookups
-Checking hashes against VirusTotal 
-Creating rules against telemetry from Windows Defender
-Checking domains using Levenshtein distance to detect spear phishing 
+* Running Sigma rules
+* Running continuous YARA scans without impacting performance
+* File and registry integrity monitoring
+* Leveraging threat feeds or lookups
+* Checking hashes against VirusTotal 
+* Creating rules against telemetry from Windows Defender
+* Checking domains using Levenshtein distance to detect spear phishing 
 
 ### Response
 
 When a detection is triggered a response action is initiated. A response can take an action on the endpoint or be used to automate many aspects of security operations. Response actions can include:
 
-Killing a process or process tree
-Triggering memory dumps
-Issuing an alert to a wide variety of destination types including the web application, any webhook, SMTP, PagerDuty, Kafka, SCP and many more.
-Initiating full PCAP capture from the network without impacting performance
-Triggering log ingestion and analysis
-The ability to deploy and run any executable on endpoint such as patches or custom scripts
+* Killing a process or process tree
+* Triggering memory dumps
+* Issuing an alert to a wide variety of destination types including the web application, any webhook, SMTP, PagerDuty, Kafka, SCP and many more.
+* Initiating full PCAP capture from the network without impacting performance
+* Triggering log ingestion and analysis
+* The ability to deploy and run any executable on endpoint such as patches or custom scripts
 
 A repository of sample detection rules can be found in this repository: [Sample Rule Set](https://github.com/refractionPOINT/rules)
 


### PR DESCRIPTION
List items were not showing up as a bulleted list.

## Two lists on the EDR page in the doc were not showing up as lists. 

> Description here

## Type of change
- [X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

