### PR TITLE
Update slack.md

### DIFF
--- a/docs/outputs/slack.md
+++ b/docs/outputs/slack.md
@@ -10,7 +10,8 @@ slack_api_token: d8vyd8yeugr387y8wgf8evfb
 slack_channel: #detections
 ```
 
-## Provisioning
+**Provisioning:**
+
 To use this Output, you need to create a Slack App and Bot. This is very simple:
 1. Head over to https://api.slack.com/apps
 1. Click on "Create App" and select the workspace where it should go


### PR DESCRIPTION
Tiny formatting error: a subtitle was showing up (h2 v2 h3) as the same size in Stoplight. Made the subtitle simply bold which I think is a good reflection of its importance in this context.

## Description of the change

> Description here

## Type of change
- [X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Describe multi-tenancy segmentation

