### PR TITLE
Typo in artifact_get command help.

### DIFF
--- a/docs/sensor_commands.md
+++ b/docs/sensor_commands.md
@@ -680,9 +680,9 @@ Retrieve an artifact from a sensor.
 Platforms: Windows, Linux, MacOS
 
 ```
-usage: log_get [-h] [--file FILE] [--source SOURCE] [--type TYPE]
-               [--payload-id PAYLOADID] [--days-retention RETENTION]
-               [--is-ignore-cert]
+usage: artifact_get [-h] [--file FILE] [--source SOURCE] [--type TYPE]
+                    [--payload-id PAYLOADID] [--days-retention RETENTION]
+                    [--is-ignore-cert]
 
 optional arguments:
   --file FILE           file path to get


### PR DESCRIPTION
## Description of the change

Typo where we used the old form of artifact_get.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

