### PR TITLE
Document new re-enroll action.

### DIFF
--- a/docs/deploy_sensor.md
+++ b/docs/deploy_sensor.md
@@ -151,7 +151,7 @@ If these occur, a [sensor_clone](events.md#sensor_clone) event will be generated
 have two choices:
 
 1. Fix the installation process and re-deploy.
-1. Run a de-duplication process with a Detection & Response rule [like this](dr.md#de-duplicate-cloned-sensors).
+1. Run a de-duplication process with a Detection & Response rule [like this](dr-examples.md#de-duplicate-cloned-sensors).
 
 Preparing sensors to run properly from templates can be done in one of two ways:
 

--- a/docs/dr-examples.md
+++ b/docs/dr-examples.md
@@ -127,12 +127,5 @@ event: sensor_clone
 op: is windows
 
 # Response
-- action: task
-  command: file_del %windir%\system32\hcp.dat
-- action: task
-  command: file_del %windir%\system32\hcp_hbs.dat
-- action: task
-  command: file_del %windir%\system32\hcp_conf.dat
-- action: task
-  command: restart
+- action: re-enroll
 ```


### PR DESCRIPTION
## Description of the change

There is a new first class action in D&R rules, `re-enroll` that will take care of all the re-enrollment steps after a cloned sensor.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

