### PR TITLE
New lookups

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -181,13 +181,13 @@ Looks up a value against a [lookup add-on](https://app.limacharlie.io/add-ons/ca
 event: DNS_REQUEST
 op: lookup
 path: event/DOMAIN_NAME
-resource: lcr://lookup/malwaredomains
+resource: hive://lookup/malwaredomains
 case sensitive: false
 ```
 
 This rule will get the `event/DOMAIN_NAME` of a `DNS_REQUEST` event and check if it's a member of the `lookup` named `malwaredomains`. If it is, then the rule is a match.  
 
-The value is supplied via the `path` parameter and the lookup is defined in the `resource` parameter. Resources are of the form `lcr://RESOURCE_TYPE/RESOURCE_NAME`. In order to access a lookup, your organization must be subscribed to it.
+The value is supplied via the `path` parameter and the lookup is defined in the `resource` parameter. Resources are of the form `lcr://RESOURCE_TYPE/RESOURCE_NAME` (for things like APIs, like `lcr://api/vt`) or `hive://lookup/my-lookup` (when referring to [lookup](lookup.md) lists). In order to access a lookup, your organization must be subscribed to it.
 
 Supports the [file name](#file-name) and [sub domain](#sub-domain) transforms.
 


### PR DESCRIPTION
## Description of the change

Moving the lookup documentation to the new-style lookups stored per-org in Hive.
Note that the format of the underlying ingest is no longer auto-detected, this is to make the feedback of errors clearer to users. Some formats are also not available right now, the plan is to add those cleanly as they come up (they're easy adds).

This will be my last push to the old-doc before our transition.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

