### PR TITLE
Document new tag preventing runtime updates.

### DIFF
--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -54,8 +54,8 @@ When you tag a sensor with _lc:no_kernel_, the kernel component will not be load
 ### lc:debug
 When you tag a sensor with _lc:debug_, the debug version of the sensor currently assigned to the Organization will be used.
 
-### lc:no-update
-When you tag a sensor with _lc:no-update_, the sensor will not update the version it's running at run-time. The version will only be loaded when the sensor starts from scratch like after a reboot.
+### lc:limit-update
+When you tag a sensor with _lc:limit-update_, the sensor will not update the version it's running at run-time. The version will only be loaded when the sensor starts from scratch like after a reboot.
 
 ### lc:sleep
 When you tag a sensor with _lc:sleep_, the sensor will keep its connection to the LimaCharlie Cloud, but will disable all other functionality to avoid any impact on the system.

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -54,5 +54,8 @@ When you tag a sensor with _lc:no_kernel_, the kernel component will not be load
 ### lc:debug
 When you tag a sensor with _lc:debug_, the debug version of the sensor currently assigned to the Organization will be used.
 
+### lc:no-update
+When you tag a sensor with _lc:no-update_, the sensor will not update the version it's running at run-time. The version will only be loaded when the sensor starts from scratch like after a reboot.
+
 ### lc:sleep
 When you tag a sensor with _lc:sleep_, the sensor will keep its connection to the LimaCharlie Cloud, but will disable all other functionality to avoid any impact on the system.


### PR DESCRIPTION
## Description of the change

Documenting basics of a new `lc:no-update` tag used to prevent a sensor from updating at runtime, only updating during reboots. This is used for servers where we don't want the behavior to change at any other time than during reboot.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


