### PR TITLE
Updated macOS latest uninstall file path

### DIFF
--- a/docs/sensor_installation/macOS_sensor_installation-latest.md
+++ b/docs/sensor_installation/macOS_sensor_installation-latest.md
@@ -114,7 +114,7 @@ To uninstall the sensor:
 
 1. Run the installer via the command line.  You'll pass the argument -c
 
-> sudo ./hcp_osx_x64_release_4.23.0 -c
+> sudo /usr/local/bin/rphcp -c
 
 <img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/Uninstallation/1-Uninstall_Progress.png" alt="Uninstall progress" style="zoom:100%;" />
 

--- a/docs/sensor_installation/macOS_sensor_installation-older.md
+++ b/docs/sensor_installation/macOS_sensor_installation-older.md
@@ -108,7 +108,7 @@ To uninstall the sensor:
 
 You'll pass the argument -c
 
-> sudo ./hcp_osx_x64_release_4.23.0 -c
+> sudo /usr/local/bin/rphcp -c
 
 <img src="https://storage.googleapis.com/limacharlie-io/doc/sensor-installation/macOS/images/macOS_10.14/Installed_correctly.png" alt="Uninstall progress" style="zoom:50%;" />
 


### PR DESCRIPTION
## Description of the change
Updated macOS uninstall file path to reference the executable already on disk instead of a freshly downloaded installer.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
> Fix [#1916](https://github.com/refractionPOINT/tracking/issues/1916) 

## Describe multi-tenancy segmentation
N/A